### PR TITLE
Fix text drawing at wrong position on Linux

### DIFF
--- a/BlueBrick/MapData/LayerText.cs
+++ b/BlueBrick/MapData/LayerText.cs
@@ -273,12 +273,12 @@ namespace BlueBrick.MapData
                     PointF center = Layer.sConvertPointInStudToPixel(cell.Center, areaInStud, scalePixelPerStud);
                     rotation.Translate(center.X, center.Y);
                     rotation.Rotate(cell.Orientation);
-                    g.Transform = rotation;
                     // get the source and destination rectangle
                     RectangleF srcRect = cell.Image.GetBounds(ref unit);
                     float halfWidth = srcRect.Width * scaleForDestinationRectangle;
                     float halfHeight = srcRect.Height * scaleForDestinationRectangle;
                     PointF[] destRect = { new PointF(-halfWidth, -halfHeight), new PointF(halfWidth, -halfHeight), new PointF(-halfWidth, halfHeight) };
+                    rotation.TransformPoints(destRect);
                     // draw the image containing the text
                     g.DrawImage(cell.Image, destRect, srcRect, unit, mImageAttribute);
 
@@ -287,7 +287,6 @@ namespace BlueBrick.MapData
                     PointF[] hull = null;
                     if (isSelected || mDisplayHulls)
                     {
-                        g.Transform = new Matrix();
                         hull = Layer.sConvertPolygonInStudToPixel(cell.SelectionArea.Vertice, areaInStud, scalePixelPerStud);
                     }
 
@@ -300,9 +299,6 @@ namespace BlueBrick.MapData
 						g.FillPolygon(mSelectionBrush, hull);
 				}
 			}
-
-            // reset the transform
-            g.Transform = new Matrix();
 
 			// call the base class to draw the surrounding selection rectangle
             base.draw(g, areaInStud, scalePixelPerStud, drawSelection);


### PR DESCRIPTION
On Linux text in `TextCell`s was always drawn in the top left corner of the map view, because `g.DrawImage` did not apply `g.Transform` (might be a bug in mono on Linux). Transforming the points of `destRect` instead works as intended.